### PR TITLE
Use print function for Python3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -y libboost-python1.48-dev
 install:
-- pip install -r requirements.txt --use-mirrors
+- pip install -r requirements.txt
 before_script:
 - rm -rf src/smhasher
 - svn checkout http://smhasher.googlecode.com/svn/trunk/ src/smhasher

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 - pip install -r requirements.txt
 before_script:
 - rm -rf src/smhasher
-- svn checkout http://smhasher.googlecode.com/svn/trunk/ src/smhasher
+- git clone https://github.com/aappleby/smhasher.git src/smhasher
 script:
 - sudo python setup.py test
 - sudo python setup.py sdist bdist

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ elif os.name == "posix":
     extra_compile_args += ["-msse4.2"]
 
 if os.getenv('TRAVIS') == 'true':
-    print "force to link boost::python base on Python version v%d.%d" % (sys.version_info.major, sys.version_info.minor)
+    print("force to link boost::python base on Python version v%d.%d" % (sys.version_info.major, sys.version_info.minor))
 
     os.remove('/usr/lib/libboost_python.so')
     os.symlink('/usr/lib/libboost_python-py%d%d.so' % (sys.version_info.major, sys.version_info.minor),


### PR DESCRIPTION
The setup.py file was using the print statement, which caused installation to fail in Python3 using pip3/easy_install3. Add parenthesis to make the file Python3 compatible.