### PR TITLE
remove python2 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -236,5 +236,4 @@ setup(name='pyhash',
       ],
       keywords='hash hashing fasthash',
       setup_requires=['pytest-runner', 'pytest-benchmark'],
-      tests_require=['pytest'],
-      use_2to3=True)
+      tests_require=['pytest'])


### PR DESCRIPTION
pyhash build failed.

```
error in pyhash setup command: use_2to3 is invalid.
```
dependency:
setuptools: 58.0.2

From setuptools v58.0.0, the use_2to3 option is no longer sopported.
https://github.com/pypa/setuptools/commit/9f75850ec2455718c4c470c16c4c15139deef624

This pull request proposes removing this option from setup.py.
I didn't see any test suite though, so I can't make sure all the code is compatible with newest version of Python.

similar issue is in
https://github.com/pallets-eco/flask-openid/issues/59