### PR TITLE
Fix memory leak on bufferable objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=42", "wheel", "pybind11>=2.8"]
+requires = ["setuptools>=42", "wheel", "pybind11>=2.8.1"]

--- a/src/Hash.h
+++ b/src/Hash.h
@@ -407,13 +407,16 @@ void handle_data(PyObject *obj, std::function<void(const char *buf, Py_ssize_t l
     py::buffer_info view = py::reinterpret_borrow<py::buffer>(obj).request(false);
     Py_ssize_t shape_accum = view.size;
 
-    for (int i = 0; i < view.ndim; ++i)
+    if (shape_accum != 0)
     {
-      shape_accum /= view.shape[i];
-
-      if (view.strides[i] != view.itemsize * shape_accum)
+      for (int i = 0; i < view.ndim; ++i)
       {
-        throw std::invalid_argument("only support contiguous buffer");
+        shape_accum /= view.shape[i];
+
+        if (view.strides[i] != view.itemsize * shape_accum)
+        {
+          throw std::invalid_argument("only support contiguous buffer");
+        }
       }
     }
 

--- a/src/Hash.h
+++ b/src/Hash.h
@@ -402,29 +402,23 @@ void handle_data(PyObject *obj, std::function<void(const char *buf, Py_ssize_t l
     }
   }
 #endif
-  else if (PyObject_CheckBuffer(obj))
+  else if (PyObject_CheckBuffer(obj) || PyMemoryView_Check(obj))
   {
-    Py_buffer view;
+    py::buffer_info view = py::reinterpret_borrow<py::buffer>(obj).request(false);
+    Py_ssize_t shape_accum = view.size;
 
-    if (-1 == PyObject_GetBuffer(obj, &view, PyBUF_SIMPLE) || !PyBuffer_IsContiguous(&view, 'C'))
+    for (int i = 0; i < view.ndim; ++i)
     {
-      throw std::invalid_argument("only support contiguous buffer");
+      shape_accum /= view.shape[i];
+
+      if (view.strides[i] != view.itemsize * shape_accum)
+      {
+        throw std::invalid_argument("only support contiguous buffer");
+      }
     }
 
-    callback((const char *)view.buf, view.len);
-    return;
-  }
-  else if (PyMemoryView_Check(obj))
-  {
-    Py_buffer *view = PyMemoryView_GET_BUFFER(obj);
-
-    if (!view || !PyBuffer_IsContiguous(view, 'C'))
-    {
-      throw std::invalid_argument("only support contiguous memoryview");
-    }
-
-    buf = (const char *)view->buf;
-    len = view->len;
+    buf = (const char *)view.ptr;
+    len = view.size;
   }
   else
   {

--- a/src/Hash.h
+++ b/src/Hash.h
@@ -405,19 +405,10 @@ void handle_data(PyObject *obj, std::function<void(const char *buf, Py_ssize_t l
   else if (PyObject_CheckBuffer(obj) || PyMemoryView_Check(obj))
   {
     py::buffer_info view = py::reinterpret_borrow<py::buffer>(obj).request(false);
-    Py_ssize_t shape_accum = view.size;
 
-    if (shape_accum != 0)
+    if (!PyBuffer_IsContiguous(view.view(), 'C'))
     {
-      for (int i = 0; i < view.ndim; ++i)
-      {
-        shape_accum /= view.shape[i];
-
-        if (view.strides[i] != view.itemsize * shape_accum)
-        {
-          throw std::invalid_argument("only support contiguous buffer");
-        }
-      }
+      throw std::invalid_argument("only support contiguous buffer");
     }
 
     buf = (const char *)view.ptr;


### PR DESCRIPTION
This pull request addresses the issue #57. Note that, the bug reported happens for any bufferable object, except for `bytes`, which are handled separately on the code.

Test code:
```python
import pyhash
import psutil
import numpy as np


hasher = pyhash.highway_128()
memory_before = psutil.Process().memory_info().rss

for _ in range(10):
    hasher(np.random.randint(0, 255, 2 ** 30, np.uint8))

memory_after = psutil.Process().memory_info().rss

print("memory increase =", memory_after - memory_before)
```

current version: `memory increase = 10737897472`
after correction: `memory increase = 593920` (probably some objects waiting for garbage collection)