### PR TITLE
fix build related errors due to t1ha moving into the smhasher repo

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,5 @@ ignore:
   - "src/lookup3"
   - "src/smhasher"
   - "src/SuperFastHash"
-  - "src/t1ha"
   - "src/wyhash"
   - "src/xxHash"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,22 +27,17 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version:
-          - "2.7"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
-          - "pypy-2.7"
-          - "pypy-3.6"
           - "pypy-3.7"
+          - "pypy-3.8"
         experimental: [false]
         include:
-          - os: macos-10.15
-            python-version: 2.x
-            experimental: false
           - os: macos-11
-            python-version: 3.x
-            experimental: false
+            python-version: 3.8
+            experimental: true
           - os: windows-latest
             python-version: 3.x
             experimental: true
@@ -65,6 +60,7 @@ jobs:
 
       - name: Install requirements
         run: |
+          pip install -U pip setuptools wheel
           pip install cpuid
           pip install -r requirements.txt
           pip install -r tests/requirements.txt

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,9 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v2
+      with:
+        submodules: true
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -52,8 +54,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -62,9 +64,9 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - run: |
+       python3.8 -m pip install cpuid
+       python3.8 setup.py build_clib build_ext --inplace
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "src/pybind11"]
 	path = src/pybind11
 	url = https://github.com/pybind/pybind11.git
-[submodule "src/t1ha"]
-	path = src/t1ha
-	url = https://github.com/leo-yuriev/t1ha.git
 [submodule "src/highwayhash"]
 	path = src/highwayhash
 	url = https://github.com/google/highwayhash.git

--- a/setup.py
+++ b/setup.py
@@ -139,12 +139,12 @@ c_libraries = [(
 ), (
     't1ha', {
         "sources": list(filter(None, [
-            'src/t1ha/src/t1ha0.c',
-            'src/t1ha/src/t1ha0_ia32aes_avx.c' if IS_X86 else None,
-            'src/t1ha/src/t1ha0_ia32aes_avx2.c' if IS_X86 else None,
-            'src/t1ha/src/t1ha0_ia32aes_noavx.c',
-            'src/t1ha/src/t1ha1.c',
-            'src/t1ha/src/t1ha2.c',
+            'src/smhasher/t1ha/t1ha0.c',
+            'src/smhasher/t1ha/t1ha0_ia32aes_avx.c' if IS_X86 else None,
+            'src/smhasher/t1ha/t1ha0_ia32aes_avx2.c' if IS_X86 else None,
+            'src/smhasher/t1ha/t1ha0_ia32aes_noavx.c',
+            'src/smhasher/t1ha/t1ha1.c',
+            'src/smhasher/t1ha/t1ha2.c',
         ])),
         "macros": [
             ("T1HA0_AESNI_AVAILABLE", ON if cpu.aes else OFF),

--- a/src/T1ha.h
+++ b/src/T1ha.h
@@ -2,7 +2,7 @@
 
 #include "Hash.h"
 
-#include "t1ha/t1ha.h"
+#include "smhasher/t1ha.h"
 
 enum t1_hash_a
 {


### PR DESCRIPTION
This PR fixes several build related issues due to recent changes in the smhasher repo as well as some fixes for the osx tests which seem to be unstable with python3.10 and installing `cpuid` 